### PR TITLE
Add Font#text_word,#text_grids , to assist with font creation.

### DIFF
--- a/font.rb
+++ b/font.rb
@@ -29,6 +29,20 @@ class Font
     end
   end
   
+  def text_word(word)
+    chars = []
+    
+    word.split('').each { |char| chars << text(char).split($/) }
+    
+    chars.transpose.map { |e| e.join(" ") } # join letters with space
+  end
+  
+  def text_grids(word_width = 80)
+    grids_per_line = (word_width + 1) / (@width + 1)
+    
+    @grids.keys.each_slice(grids_per_line).map { |w| text_word(w.join) << $/ }
+  end
+  
   def dcled(char)
     @cache[:dcled][char] ||= if grid = @grids[char.to_sym]
       o = grid_def(grid).map { |e| (e + 1) % 2 } # flip bits


### PR DESCRIPTION
Add `Font#text_word` to join output from `#text`, suitable for display on screen. This is a basic implementation, which could well be improved by refactoring across `Font` (lines are joined with `\n` and then split on `\n` again). This provides swift feedback during the preparation of fonts. e.g.

```
ruby -e "require './font'; f = Font.new('./fonts/default.yml'); puts f.text_word('peace')"
```

Add `Font#text_grids`, for displaying entire font on screen. This iterates through all grids defined for a font, displaying as many grids per line using `#text_word` as fits within `word_width`, adding spaces between lines. This enables an entire font to be output to screen.

Peace,
tiredpixel
